### PR TITLE
docs: add framer-motion and lucide-react to peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,8 @@ npm install ms-ui-kit
 
 > **Peer dependencies** — make sure your project already has these:
 > ```bash
-> npm install react react-dom
+> npm install react react-dom framer-motion lucide-react
 > ```
-
 ---
 
 ## Quick Start


### PR DESCRIPTION
Summary
Added framer-motion and lucide-react to the recommended peer dependencies in the Installation section.

Fixes #44

Why it is needed: The library's core features heavily rely on Framer Motion for micro-interactions, and the README's code examples explicitly import icons from lucide-react (e.g., the <Zap /> icon in the Button component). Listing these alongside react and react-dom ensures that new users don't encounter "Module Not Found" crashes when copy-pasting the quick start examples into fresh Vite environments.

Testing
Verified the formatting remains clean in the Markdown block.

Checklist
[x] I have tested the change locally.

[x] I have updated documentation if needed.