### PR TITLE
Fix: Replace default Vite favicon with MS UI KIT branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/vscode_extension/icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MS UI KIT</title>
   </head>


### PR DESCRIPTION
## Summary
This PR replaces the default Vite favicon with the official MS UI KIT icon to ensure consistent project branding.

## Changes Made
- Replaced the default Vite favicon with the MS UI KIT favicon.
- Updated the favicon reference to use the project-specific icon.

## Testing
- Verified that the browser tab now displays the MS UI KIT icon.
- Confirmed that the favicon loads correctly across the application.

## Screenshot
<img width="320" height="53" alt="image" src="https://github.com/user-attachments/assets/e3e8b561-7c06-482b-aeaf-7df5efd2f35b" />
<img width="1918" height="1078" alt="image" src="https://github.com/user-attachments/assets/360103a7-90d1-46ef-ba1c-62cbeeff43e6" />

Closes #46