### PR TITLE
feat: add GitHub Actions CI workflow for ESLint and Vite library build validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,28 +2,39 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
-  build:
+  lint-and-build:
+    name: Lint and build library
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Use Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-        cache: 'npm'
-        
-    - name: Install dependencies
-      run: npm install
-      
-    - name: Run lint
-      run: npm run lint
-      
-    - name: Run build
-      run: npm run build
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Build library bundle
+        run: npm run build:lib
+
+      - name: Verify dist entry point exists
+        run: |
+          if [ ! -f "dist/components/index.js" ]; then
+            echo "ERROR: dist/components/index.js not found."
+            echo "The library entry point is missing after build."
+            exit 1
+          fi
+          echo "dist/components/index.js found — build OK"

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ vscode_extension/ms-ui-kit-1.0.0.vsix
 vscode_extension/ms-ui-kit-1.0.1.vsix
 vscode_extension/ms-ui-kit-1.0.2.vsix
 vscode_extension/ms-ui-kit-1.0.3.vsix
+
+# Linting artifacts (run-time generated, not committed)
+lint_report.json


### PR DESCRIPTION
Closes #53

Summary
Adds a GitHub Actions CI pipeline that runs on every PR and push to main.

Changes made
• Created .github/workflows/ci.yml — runs npm ci, npm run lint, npm run build:lib, then verifies dist/components/index.js exists (the package entry point from package.json).
• Added lint_report.json to .gitignore so stale linting artifacts are no longer committed.

Why
Without CI, broken builds can silently merge to main and reach npm consumers of ms-ui-kit. This ensures every contribution passes lint and produces a valid dist/ output before merging.

Testing
The Actions tab on this PR will show the workflow run. Both lint and build steps must pass green.